### PR TITLE
Flatten Ansible playbook layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # cloud-config-ansible
-Contains Ansible playbooks which are fed to Cloud Init scripts on boot
+Contains Ansible playbooks which are fed to Cloud Init scripts on boot.
+
+## Playbooks
+
+### `common-dev-tools`
+
+Installs a baseline set of development tooling (compilers, build helpers, git, curl, etc.)
+and automatically handles both Debian-based and RHEL/Rocky-based systems. The playbook
+leverages Ansible facts to detect the OS family at runtime and executes the appropriate
+package manager commands, including the `@Development Tools` group on Red Hat derivatives.
+
+Run a syntax check locally with:
+
+```bash
+ansible-playbook --syntax-check common-dev-tools.yml
+```

--- a/common-dev-tools.yml
+++ b/common-dev-tools.yml
@@ -1,0 +1,33 @@
+---
+- name: Configure common development tools
+  hosts: all
+  become: true
+  gather_facts: true
+
+  vars:
+    supported_os_families:
+      - debian
+      - redhat
+    base_packages:
+      - git
+      - curl
+      - wget
+      - cmake
+      - make
+      - pkg-config
+      - python3
+      - python3-pip
+      - unzip
+
+  tasks:
+    - name: Ensure operating system family is supported
+      ansible.builtin.assert:
+        that:
+          - ansible_facts['os_family'] | lower in supported_os_families
+        success_msg: "OS family {{ ansible_facts['os_family'] }} is supported"
+        fail_msg: >-
+          The common-dev-tools playbook currently supports Debian/Ubuntu and
+          RHEL/Rocky based distributions.
+
+    - name: Include OS-specific package installation tasks
+      ansible.builtin.include_tasks: "{{ playbook_dir }}/tasks/{{ ansible_facts['os_family'] | lower }}.yml"

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,0 +1,17 @@
+---
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Install development packages on Debian-based systems
+  ansible.builtin.apt:
+    name: "{{ base_packages + debian_extra_packages }}"
+    state: present
+    install_recommends: true
+  vars:
+    debian_extra_packages:
+      - build-essential
+      - gdb
+      - ninja-build
+      - software-properties-common

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,0 +1,33 @@
+---
+- name: Ensure package metadata is up to date (dnf)
+  ansible.builtin.dnf:
+    update_cache: true
+  when: ansible_facts['pkg_mgr'] == 'dnf'
+
+- name: Ensure package metadata is up to date (yum)
+  ansible.builtin.yum:
+    update_cache: true
+  when: ansible_facts['pkg_mgr'] == 'yum'
+
+- name: Install Development Tools group (dnf)
+  ansible.builtin.dnf:
+    name: "@Development Tools"
+    state: present
+  when: ansible_facts['pkg_mgr'] == 'dnf'
+
+- name: Install Development Tools group (yum)
+  ansible.builtin.yum:
+    name: "@Development Tools"
+    state: present
+  when: ansible_facts['pkg_mgr'] == 'yum'
+
+- name: Install development packages on RHEL-based systems
+  ansible.builtin.package:
+    name: "{{ base_packages + redhat_extra_packages }}"
+    state: present
+  vars:
+    redhat_extra_packages:
+      - gcc
+      - gcc-c++
+      - gdb
+      - ninja-build


### PR DESCRIPTION
## Summary
- relocate the `common-dev-tools` playbook to the repository root and move shared task files alongside it
- update the OS-specific include path to resolve via `playbook_dir`
- refresh the README syntax-check instructions to match the new layout

## Testing
- not run (ansible-playbook not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e579d5d8648322b4cc5e23b4a98e88